### PR TITLE
Remove eslint-plugin-prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,16 @@ As another line of defense, if you want ESLint to automatically fix your errors 
 
 ```json
 {
-  "scripts": {
-    "precommit": "lint-staged"
-  },
   "lint-staged": {
-    "*.js": ["eslint --fix", "git add"]
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged",
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ This package has several [peerDependencies](https://docs.npmjs.com/files/package
 #### npm
 
 ```sh
-npm install --save-dev @upstatement/eslint-config eslint babel-eslint prettier eslint-config-prettier eslint-plugin-prettier
+npm install --save-dev @upstatement/eslint-config eslint babel-eslint prettier eslint-config-prettier
 ```
 
 #### yarn
 
 ```sh
-yarn add --dev @upstatement/eslint-config eslint babel-eslint prettier eslint-config-prettier eslint-plugin-prettier
+yarn add --dev @upstatement/eslint-config eslint babel-eslint prettier eslint-config-prettier
 ```
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 module.exports = {
   'extends': [
     'eslint:recommended',
-    'plugin:prettier/recommended'
   ],
-  'plugins': ['prettier'],
   'parser': 'babel-eslint',
   'parserOptions': {
     'ecmaVersion': 2018,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   'extends': [
     'eslint:recommended',
+    'prettier',
   ],
   'parser': 'babel-eslint',
   'parserOptions': {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "eslint": "^5.x.x",
     "babel-eslint": "^10.x.x",
     "prettier": "^1.x.x",
-    "eslint-config-prettier": "^3.x.x",
-    "eslint-plugin-prettier": "^3.x.x"
+    "eslint-config-prettier": "^3.x.x"
   }
 }


### PR DESCRIPTION
Removing `eslint-plugin-prettier` because it was overriding prettier with the default recommended config, not ups config. Removing it will allow users to opt in or out to using prettier