### PR TITLE
Bump eslint version from 7 to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pairs well with our [Prettier config](https://www.npmjs.com/package/@upstatement
       - [Using Create React App?](#using-create-react-app)
     - [Vue Config](#vue-config)
   - [Specifying Environments](#specifying-environments)
-  - [Editor Integration & Autoformatting](#editor-integration--autoformatting)
+  - [Editor Integration \& Autoformatting](#editor-integration--autoformatting)
     - [VS Code](#vs-code)
     - [Sublime Text](#sublime-text)
     - [Atom](#atom)
@@ -46,11 +46,11 @@ Run `npm info "@upstatement/eslint-config@latest" peerDependencies` to list the 
     - **Option 2:** Without `npx`
 
       ```sh
-      npm install --save-dev @upstatement/eslint-config @babel/core@7.x.x @babel/eslint-parser@7.x.x eslint@7.x.x eslint-config-prettier@8.x.x prettier@2.x.x
+      npm install --save-dev @upstatement/eslint-config @babel/core@7.x.x @babel/eslint-parser@7.x.x eslint@8.x.x eslint-config-prettier@8.x.x prettier@2.x.x
 
       # or
 
-      yarn add --dev @upstatement/eslint-config @babel/core@7.x.x @babel/eslint-parser@7.x.x eslint@7.x.x eslint-config-prettier@8.x.x prettier@2.x.x
+      yarn add --dev @upstatement/eslint-config @babel/core@7.x.x @babel/eslint-parser@7.x.x eslint@8.x.x eslint-config-prettier@8.x.x prettier@2.x.x
       ```
 
 3. Create an `.eslintrc` file at the root of your project with the following:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "@babel/core": "^7.x.x",
     "@babel/eslint-parser": "^7.x.x",
-    "eslint": "^7.x.x",
+    "eslint": "^8.x.x",
     "eslint-config-prettier": "^8.x.x",
     "prettier": "^2.x.x"
   }


### PR DESCRIPTION
## Changes

Bumps `eslint` version from 7 to 8

## How to test

Create a local test project

```shell
mkdir eslint-test && cd eslint-test && npm init -y && touch .eslintrc && touch index.js
```

Then install this package's peer deps (including eslint 8) with the ` --legacy-peer-deps` flag

```shell
npm install --save-dev @upstatement/eslint-config @babel/core@7.x.x @babel/eslint-parser@7.x.x eslint@8.x.x eslint-config-prettier@8.x.x prettier@2.x.x --legacy-peer-deps
```

In the `.eslintrc` file add
```json
{
  "root": true,
  "extends": "@upstatement"
}
```

Then in `index.js` add some JS that does not pass linting rules like
```js
const thing = {
  hi: 'hello',
    hey: 'hi'
};
```

Confirm linting issues are identified with red squigglies

<img width="301" alt="image" src="https://user-images.githubusercontent.com/6599979/219129122-2201ec47-14b6-4f41-b9fa-9400115ee238.png">
